### PR TITLE
feat: Make the repository a derived store

### DIFF
--- a/src/lib/components/HeaderCell.svelte
+++ b/src/lib/components/HeaderCell.svelte
@@ -2,7 +2,7 @@
 	import type { Column } from '$lib/types';
 
 	import { SortDirection } from '$lib/types';
-	import { repository } from '$lib/stores/repository';
+	import { filter } from '$lib/stores/filter';
 	import { sort } from '$lib/stores/sort';
 
 	import Ascending from './icons/Ascending.svelte';
@@ -12,26 +12,28 @@
 
 	export let column: Column;
 
-	let filter: string;
-	let filterHidden = true;
+	let filterValue: string;
+	let isFilterHidden = true;
 
 	function sortRows() {
 		sort.set(column.key);
-		repository.sort($sort.key, $sort.direction);
 	}
 
 	function filterRows(event: KeyboardEvent) {
 		if (event.key === 'Enter') {
-			repository.filter(column.key, filter);
+			filter.set({
+				key: column.key,
+				value: filterValue
+			});
 		}
 	}
 
 	function toggleFilter() {
-		filterHidden = !filterHidden;
+		isFilterHidden = !isFilterHidden;
 	}
 
 	function hideFilter() {
-		filterHidden = true;
+		isFilterHidden = true;
 	}
 </script>
 
@@ -48,13 +50,13 @@
 
 			<div
 				class="absolute left-0 top-full p-5 border border-slate-200 rounded bg-white cursor-default"
-				class:hidden={filterHidden}
+				class:hidden={isFilterHidden}
 				on:click|stopPropagation
 			>
 				<input
 					type="text"
 					class="border border-slate-200 rounded px-2 py-1"
-					bind:value={filter}
+					bind:value={filterValue}
 					on:keyup={filterRows}
 				/>
 			</div>

--- a/src/lib/components/Table.svelte
+++ b/src/lib/components/Table.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Column } from '$lib/types';
 
+	import { dataset } from '$lib/stores/dataset';
 	import { repository } from '$lib/stores/repository';
 
 	import DataCell from './DataCell.svelte';
@@ -10,7 +11,7 @@
 	export let columns: Column[];
 	export let data: any[]; // eslint-disable-line @typescript-eslint/no-explicit-any
 
-	repository.init(data);
+	dataset.init(data);
 </script>
 
 <div class="flex flex-col gap-1 divide-y divid-solid p-2">

--- a/src/lib/stores/dataset.ts
+++ b/src/lib/stores/dataset.ts
@@ -1,0 +1,29 @@
+import type { DataSet } from '$lib/types';
+import type { Writable } from 'svelte/store';
+
+import { writable } from 'svelte/store';
+import { createDataRows } from '$lib/utils/data';
+
+function create() {
+	const store: Writable<DataSet> = writable({
+		rows: []
+	});
+
+	const { subscribe, set } = store;
+
+	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+	function init(data: any[]) {
+		const rows = createDataRows(data);
+
+		set({
+			rows: rows
+		});
+	}
+
+	return {
+		subscribe,
+		init
+	};
+}
+
+export const dataset = create();

--- a/src/lib/stores/filter.ts
+++ b/src/lib/stores/filter.ts
@@ -1,0 +1,6 @@
+import type { FilterState } from '$lib/types';
+import type { Writable } from 'svelte/store';
+
+import { writable } from 'svelte/store';
+
+export const filter: Writable<FilterState> = writable();

--- a/src/lib/stores/repository.ts
+++ b/src/lib/stores/repository.ts
@@ -1,10 +1,13 @@
-import type { DataRow } from '$lib/types';
 import type { DataSet } from '$lib/types';
-import type { Writable } from 'svelte/store';
+import type { FilterState } from '$lib/types';
+import type { SortState } from '$lib/types';
+import type { DataRow } from '$lib/types';
 
-import { writable } from 'svelte/store';
+import { derived } from 'svelte/store';
+import { dataset } from './dataset';
+import { filter } from './filter';
+import { sort } from './sort';
 import { getRowValue } from '$lib/utils';
-import { createDataRows } from '$lib/utils/data';
 import { SortDirection } from '$lib/types';
 
 function rowComparator(row1: DataRow, row2: DataRow, key: string): number {
@@ -14,66 +17,47 @@ function rowComparator(row1: DataRow, row2: DataRow, key: string): number {
 	return value1.localeCompare(value2);
 }
 
-function sortRows(rows: DataRow[], key: string, direction: SortDirection): DataRow[] {
+function sortRows(rows: DataRow[], state: SortState): DataRow[] {
+	if (state === undefined || state === null) {
+		return rows;
+	}
+
 	rows.sort((row1: DataRow, row2: DataRow) => {
-		if (direction === SortDirection.Ascending) {
-			return rowComparator(row1, row2, key);
+		if (state.direction === SortDirection.Ascending) {
+			return rowComparator(row1, row2, state.key);
 		}
 
-		return rowComparator(row2, row1, key);
+		return rowComparator(row2, row1, state.key);
 	});
 
 	return rows;
 }
 
-function filterRows(rows: DataRow[], key: string, value: string): DataRow[] {
-	const result = rows.filter((row) => {
-		const dataItemValue = getRowValue(row, key) || '';
+function filterRows(rows: DataRow[], state: FilterState): DataRow[] {
+	if (state === undefined || state === null) {
+		return rows;
+	}
 
-		return dataItemValue.includes(value);
+	const result = rows.filter((row) => {
+		const dataItemValue = getRowValue(row, state.key) || '';
+
+		return dataItemValue.includes(state.value);
 	});
 
 	return result;
 }
 
-function create() {
-	const store: Writable<DataSet> = writable();
-	const { subscribe, update, set: set } = store;
+function transform(originalDataSet: DataSet, sortState: SortState, filterState: FilterState) {
+	const filtered = filterRows(originalDataSet.rows, filterState);
+	const sorted = sortRows(filtered, sortState);
 
-	function sort(key: string, direction: SortDirection) {
-		update((dataset) => {
-			return {
-				_rows: dataset._rows,
-				rows: sortRows(dataset.rows, key, direction)
-			};
-		});
-	}
-
-	function filter(key: string, value: string) {
-		update((dataset) => {
-			return {
-				_rows: dataset._rows,
-				rows: filterRows(dataset._rows, key, value)
-			};
-		});
-	}
-
-	/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-	function init(data: any[]) {
-		const rows = createDataRows(data);
-
-		set({
-			_rows: rows,
-			rows: rows
-		});
-	}
-
-	return {
-		subscribe,
-		init,
-		sort,
-		filter
+	const result: DataSet = {
+		rows: sorted
 	};
+
+	return result;
 }
 
-export const repository = create();
+export const repository = derived([dataset, sort, filter], ([$dataset, $sort, $filter]) =>
+	transform($dataset, $sort, $filter)
+);

--- a/src/lib/stores/sort.ts
+++ b/src/lib/stores/sort.ts
@@ -1,3 +1,6 @@
+import type { SortState } from '$lib/types';
+import type { Writable } from 'svelte/store';
+
 import { SortDirection } from '$lib/types';
 import { writable } from 'svelte/store';
 
@@ -10,7 +13,7 @@ function changeSortDirection(current: SortDirection) {
 }
 
 function create() {
-	const store = writable({
+	const store: Writable<SortState> = writable({
 		key: '',
 		direction: SortDirection.None
 	});

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -13,7 +13,6 @@ export type DataRow = {
 };
 
 export type DataSet = {
-	_rows: DataRow[];
 	rows: DataRow[];
 };
 
@@ -22,3 +21,13 @@ export enum SortDirection {
 	Descending,
 	None
 }
+
+export type SortState = {
+	key: string;
+	direction: SortDirection;
+};
+
+export type FilterState = {
+	key: string;
+	value: string;
+};


### PR DESCRIPTION
This commit modifies the repository store so that it is derived from the
original data, the filter state, and the sort state.  To do this I
needed to create new stores for the original data set and the filter
state.  In addition I added some concrete types for the filter and sort
states.  By making the repository derived, we only need to update the
individual stores whenever a filter or sort action occurs and then the
table should react automatically.