### PR TITLE
fix: Handle numeric column sorting

### DIFF
--- a/src/lib/stores/dataset.ts
+++ b/src/lib/stores/dataset.ts
@@ -5,8 +5,8 @@ import type { Writable } from 'svelte/store';
 
 import { writable } from 'svelte/store';
 
-function sanitizeValue(value: unknown): string {
-	if (typeof value === 'string') {
+function sanitizeValue(value: unknown): string | number {
+	if (typeof value === 'string' || typeof value === 'number') {
 		return value;
 	}
 

--- a/src/lib/stores/repository.ts
+++ b/src/lib/stores/repository.ts
@@ -13,10 +13,22 @@ import { getRowValue } from '$lib/utils';
 import { SortDirection } from '$lib/types';
 
 function rowComparator(row1: DataRow, row2: DataRow, key: string): number {
-	const value1 = getRowValue(row1, key) || '';
-	const value2 = getRowValue(row2, key) || '';
+	const value1 = getRowValue(row1, key);
+	const value2 = getRowValue(row2, key);
 
-	return value1.localeCompare(value2);
+	if (value1 === value2) {
+		return 0;
+	}
+
+	if (value1 === null) {
+		return -1;
+	}
+
+	if (value2 === null) {
+		return 1;
+	}
+
+	return value1 < value2 ? -1 : 1;
 }
 
 function sortRows(rows: DataRow[], state: SortState): DataRow[] {
@@ -41,9 +53,13 @@ function filterRows(rows: DataRow[], state: FilterState | null): DataRow[] {
 	}
 
 	const result = rows.filter((row) => {
-		const dataItemValue = getRowValue(row, state.key) || '';
+		const dataItemValue = getRowValue(row, state.key);
 
-		return dataItemValue.includes(state.value);
+		if (dataItemValue === null) {
+			return false;
+		}
+
+		return dataItemValue.toString().includes(state.value);
 	});
 
 	return result;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -7,7 +7,7 @@ export type Column = {
 
 export type DataItem = {
 	key: string;
-	value: string;
+	value: string | number;
 };
 
 export type DataRow = {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,6 +1,6 @@
 import type { DataRow } from '$lib/types';
 
-function getRowValue(row: DataRow, key: string): string | null {
+function getRowValue(row: DataRow, key: string): string | number | null {
 	const dataItem = row.items.find((item) => item.key === key);
 
 	if (dataItem === undefined) {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -7,17 +7,20 @@
 		{
 			key: 'id',
 			header: 'ID',
-			filterable: true
+			filterable: true,
+			sortable: true
 		},
 		{
 			key: 'userId',
 			header: 'User ID',
-			filterable: true
+			filterable: true,
+			sortable: true
 		},
 		{
 			key: 'title',
 			header: 'Title',
-			filterable: true
+			filterable: true,
+			sortable: true
 		}
 	];
 


### PR DESCRIPTION
This commit adds support for numbers to the internal data item value
type so that we can properly sort numeric values.  Without this change
the sort of numeric values would incorrectly follow the sort of their
string representations.