### PR TITLE
refactor: Remove the default text color variable

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -4,7 +4,6 @@
 
 @layer base {
 	:root {
-		--color-text-base: 0 0 0;
 		--color-text-inverted: 255 255 255;
 		--color-facade: 255 255 255;
 		--color-primary: 8 145 178;

--- a/src/lib/tailwind.plugin.cjs
+++ b/src/lib/tailwind.plugin.cjs
@@ -26,7 +26,6 @@ module.exports = plugin(() => {}, {
 			},
 			textColor: {
 				spek: {
-					base: withOpacity('--color-text-base'),
 					inverted: withOpacity('--color-text-inverted')
 				}
 			}


### PR DESCRIPTION
This commit removes the default text color variable since this can just be inherited from the parent HTML elements.