### PR TITLE
ci: Give the workflow access to the ID token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Create bot access token
         id: app-token


### PR DESCRIPTION
This commit configures the GitHub workflow to have access to the ID token required to generate npm provenance.

https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions